### PR TITLE
fix symlinks and add md5sum for i686

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,21 +4,18 @@
 
 pkgname=sensu-bin
 pkgver=0.26.1
-deb_ver=0.26.1-1
-pkgrel=2
+_deb_ver=0.26.1-1
+pkgrel=3
 pkgdesc="Omnibus version of Sensu, the open source monitoring framework. Direct from the .deb"
 arch=('i686' 'x86_64')
 license=('MPL' 'GPL' 'LGPL')
 url="http://sensuapp.org/"
-
-if [ "${CARCH}" = 'x86_64' ]; then
-  ARCH='amd64'
-md5sums=('00d7058ef033c0e9647805bd9d9f9069')
-elif [ "${CARCH}" = 'i686' ]; then
-  ARCH='i386'
-fi
 install=sensu.install
-source=("https://core.sensuapp.com/apt/pool/sensu/main/s/sensu/sensu_${deb_ver}_${ARCH}.deb")
+source_x86_64=("https://core.sensuapp.com/apt/pool/sensu/main/s/sensu/sensu_${_deb_ver}_amd64.deb")
+source_i686=("https://core.sensuapp.com/apt/pool/sensu/main/s/sensu/sensu_${_deb_ver}_i386.deb")
+
+md5sums_x86_64=('00d7058ef033c0e9647805bd9d9f9069')
+md5sums_i686=('33c8ba279d8d603c3b25ffc784dc91c7')
 
 package() {
   tar xzvf ${srcdir}/data.tar.gz -C ${pkgdir}/
@@ -27,8 +24,7 @@ package() {
   rm -rf "${pkgdir}"/opt/sensu/sv/sensu-dashboard
 
   mkdir -p "${pkgdir}"/usr/lib/systemd/system
-  ln -s "${pkgdir}"/usr/share/sensu/systemd/sensu-api.service "${pkgdir}"/usr/lib/systemd/system/
-  ln -s "${pkgdir}"/usr/share/sensu/systemd/sensu-client.service "${pkgdir}"/usr/lib/systemd/system/
-  ln -s "${pkgdir}"/usr/share/sensu/systemd/sensu-server.service "${pkgdir}"/usr/lib/systemd/system/  
-  #cp "${pkgdir}"/opt/sensu/embedded/bin/sensu-ctl "${pkgdir}"/usr/bin/sensu-ctl
+  ln -s "/usr/share/sensu/systemd/sensu-api.service" "${pkgdir}/usr/lib/systemd/system/"
+  ln -s "/usr/share/sensu/systemd/sensu-client.service" "${pkgdir}/usr/lib/systemd/system/"
+  ln -s "/usr/share/sensu/systemd/sensu-server.service" "${pkgdir}/usr/lib/systemd/system/" 
 }


### PR DESCRIPTION
I built the package on a Vagrant box and this resulted in the following wrong symlinks:

```
[root@monitoring01 system]# ls -la sensu*
lrwxrwxrwx 1 root root 84 Sep 20 08:48 sensu-api.service -> /home/vagrant/sensu-pkgbuild/pkg/sensu-bin/usr/share/sensu/systemd/sensu-api.service
lrwxrwxrwx 1 root root 87 Sep 20 08:48 sensu-client.service -> /home/vagrant/sensu-pkgbuild/pkg/sensu-bin/usr/share/sensu/systemd/sensu-client.service
lrwxrwxrwx 1 root root 87 Sep 20 08:48 sensu-server.service -> /home/vagrant/sensu-pkgbuild/pkg/sensu-bin/usr/share/sensu/systemd/sensu-server.service
[root@monitoring01 system]# ls -la /home/vagrant/sensu-pkgbuild/pkg/sensu-bin/usr/share/sensu/systemd/sensu-api.service
```

Fixed the `PKGBUILD` as [per the documentation](https://wiki.archlinux.org/index.php/creating_packages#package.28.29) and also added an MD5SUM for the `i686` package.
